### PR TITLE
overloaded $date8_val fix

### DIFF
--- a/app_v2.py
+++ b/app_v2.py
@@ -122,7 +122,7 @@ def query_formatter(query):
                 query_formatter(query[key])
 
         else:
-            if str(query[key]).startswith("$date"):
+            if str(query[key]).startswith("$date") and str(query[key]) != "$date8_val":
                 date_str = str(query[key]).replace("$date", "").replace("(", "").replace(")", "").strip()
                 date_obj = parser.parse(date_str)
                 query[key] = date_obj


### PR DESCRIPTION
The check for the query-reformatting feature '$date(<date>}' -> datetime rewrites legitimate queries attempting to use '$date8_val', because they share the same initial substring.

Example: aggregate=[{"$project":{"year":{"$year":"$date8_val"}}},{"$limit":10}]
The query reformatter attempts to parse a datetime object from the string from '8_val'.

Untested.